### PR TITLE
NLP-ENGINE-MAC-008 full-analyzer compile + python compile API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Learn more:
 | [data/rfb/](data/rfb/) | The default "rfb" analyzer data tree (specs/grammar passes used by the engine at runtime). |
 | [data/rfb/spec/](data/rfb/spec/) | NLP++ pass files (`*.nlp`) and `analyzer.seq` defining the default analyzer pipeline. |
 | [compile-libs/](compile-libs/) | Headers (`include/Api/`, `include/cs/`) and engine static libraries (`lib/lib{prim,kbm,consh,words,lite}.a` + ICU) used to link a compiled analyzer/KB into a `.dylib`. Populated by the workflow from upstream's `nlpengine-compile-libs-macos.zip`. |
-| [scripts/compile-analyzer.sh](scripts/compile-analyzer.sh) | Compile the analyzer's KB into `<analyzer>/bin/kb.dylib`. |
+| [scripts/compile-analyzer.sh](scripts/compile-analyzer.sh) | Compile the analyzer (run+kb) into `<analyzer>/bin/run.dylib` + `<analyzer>/bin/kb.dylib`. |
 | [python/](python/) | A simple Python wrapper class for invoking `nlp.exe` from scripts. See [python/README.md](python/README.md). |
 | [.github/workflows/nlp-engine-build.yml](.github/workflows/nlp-engine-build.yml) | The GitHub Actions workflow that pulls the latest engine release. |
 
@@ -86,37 +86,54 @@ engine.analyzeInput("my-analyzer", "sample.txt", dev=True)
 
 For **production** use, prefer the native Python bindings in the [py-package-nlpengine](https://github.com/VisualText/py-package-nlpengine) repository, which avoids the subprocess round-trip.
 
-## Compiling an analyzer's KB to a native dylib
+## Compiling an analyzer to native dylibs
 
-By default `nlp.exe` runs analyzers fully interpreted. With the new `EMBEDED_KB`-enabled engine, the **knowledge base** can be compiled to a native shared library that the engine `dlopen`s at `-COMPILED` time and calls into via a single exported `kb_setup` symbol. (Analyzer pass code itself is still interpreted — upstream removed `ana_gen` in 1999, so there is no compiled-rules path; the engine falls back to interpreted execution for the rules.)
+By default `nlp.exe` runs analyzers fully interpreted from the `.nlp`
+source. With the engine's `-COMPILED` mode, both the **analyzer body**
+(the rule passes) and the **knowledge base** are compiled to native
+shared libraries that the engine `dlopen`s at runtime — the analyzer
+runs entirely from compiled code, so source edits to `.nlp` files
+between runs don't affect the output until you recompile.
 
 | Script | What it does | Output |
 |--------|--------------|--------|
-| [scripts/compile-analyzer.sh](scripts/compile-analyzer.sh) | Runs `nlp.exe -COMPILE` (emits `Cc_code.cpp` plus the `Sym*.cpp` / `Con*.cpp` / `Ptr*.cpp` / `St*.cpp` tables under `<analyzer>/kb/`), generates a one-line `kb_setup()` shim, and links everything into a single SHARED library against `compile-libs/`. Only `kb_setup` is exported (`-fvisibility=hidden` everywhere else). | `<analyzer>/bin/kb.dylib` |
+| [scripts/compile-analyzer.sh](scripts/compile-analyzer.sh) | Runs `nlp.exe -COMPILE` (emits the analyzer C++ trees under `<analyzer>/run/` and `<analyzer>/kb/`), then links everything into a single SHARED library against `compile-libs/`. The library exports both `run_analyzer(Parse*)` and `kb_setup(void*)` (engine codegen emits both). | `<analyzer>/bin/run.dylib`<br>`<analyzer>/bin/runu.dylib`<br>`<analyzer>/bin/kb.dylib`<br>`<analyzer>/bin/kbu.dylib` |
+
+The same library is staged under all four filenames so the engine's
+load paths find it whether it's looking for the ANSI or UNICODE
+build flavour ([lite/nlp.cpp:1242](https://github.com/VisualText/nlp-engine/blob/master/lite/nlp.cpp#L1242) / [cs/libconsh/cg.cpp:168](https://github.com/VisualText/nlp-engine/blob/master/cs/libconsh/cg.cpp#L168)).
 
 Prerequisites: `cmake` ≥ 3.16 and a recent Xcode Command Line Tools install (`xcode-select --install`).
 
 Usage:
 
 ```bash
-# Compile the bundled rfb analyzer's KB:
+# Default: full-analyzer compile (run + kb):
 ./scripts/compile-analyzer.sh data/rfb data/rfb/input/text.txt
 
-# Run with the compiled KB (rules stay interpreted, KB is dlopen'd):
+# Legacy: KB-only compile (matches the pre-NLP-ENGINE-MAC-008 behaviour):
+./scripts/compile-analyzer.sh --kb-only data/rfb data/rfb/input/text.txt
+
+# Run with the compiled artifacts:
 ./nlp.exe -COMPILED -ANA data/rfb -WORK . data/rfb/input/text.txt
 ```
 
-What you should see in the `-COMPILED` output for a successful round-trip:
+What you should see in the `-COMPILED` output for a successful
+round-trip:
 
 ```
 [CG: Trying to load compiled KB.]
 [Loading compiled kb: data/rfb/bin/kb.dylib]
 [Loaded compiled kb library]
-[Loading compiled analyzer ...]
-[Error: Couldn't load compiled analyzer.]      # expected — no run.dylib exists
-[No compiled analyzer; falling back to interpreted.]
-... normal parse output ...
+[Loading compiled analyzer data/rfb/bin/run.dylib]
+[Loaded compiled analyzer]
+... parse output ...
 ```
+
+If you edit an `.nlp` file under `data/rfb/spec/` and re-run
+`-COMPILED` without re-running `compile-analyzer.sh`, the output
+should be **unchanged** — that's the proof the compiled libraries
+are doing the work, not the interpreter.
 
 > **Architecture:** The bundled `nlp.exe` is built for Apple Silicon (`arm64`) only — the compile script sets `CMAKE_OSX_ARCHITECTURES=arm64` to match. Intel Macs are not supported by upstream's macOS build.
 

--- a/scripts/compile-analyzer.sh
+++ b/scripts/compile-analyzer.sh
@@ -1,34 +1,69 @@
 #!/usr/bin/env bash
 #
-# compile-analyzer.sh — Compile an NLP++ analyzer's KB into the native shared
-# library that the EMBEDED_KB-enabled engine dlopens at -COMPILED time.
+# compile-analyzer.sh — Compile an NLP++ analyzer into the native shared
+# libraries that the -COMPILED engine dlopens at runtime.
 #
 # Usage:
-#   scripts/compile-analyzer.sh <analyzer-dir> <input-file>
+#   scripts/compile-analyzer.sh [--kb-only] <analyzer-dir> <input-file>
 #
 # Example:
 #   scripts/compile-analyzer.sh data/rfb data/rfb/input/text.txt
+#   scripts/compile-analyzer.sh --kb-only data/rfb data/rfb/input/text.txt
 #
-# Produces: <analyzer-dir>/bin/kb.dylib
+# Produces (default, full-analyzer mode):
+#   <analyzer-dir>/bin/run.dylib
+#   <analyzer-dir>/bin/runu.dylib
+#   <analyzer-dir>/bin/kb.dylib
+#   <analyzer-dir>/bin/kbu.dylib
 #
-# How it fits into the runtime:
-#   - `nlp -COMPILE` emits Cc_code.cpp + the Sym*.cpp / Con*.cpp / Ptr*.cpp /
-#     St*.cpp KB tables under <analyzer-dir>/kb/. (ana_gen was removed from
-#     upstream around 1999, so there is no run.dylib equivalent — the engine
-#     falls back to interpreted execution for the analyzer rules.)
-#   - This script wraps those generated tables together with a one-line
-#     kb_setup() shim, builds them into a SHARED library, and drops it at
-#     <analyzer-dir>/bin/kb.dylib (the hardcoded path the engine dlopens).
-#   - Only kb_setup is exported (-fvisibility=hidden everywhere else) so the
-#     ABI surface mirrors the Windows export model.
+# Produces (--kb-only):
+#   <analyzer-dir>/bin/kb.dylib
+#   <analyzer-dir>/bin/kbu.dylib
 #
-# Architecture note: the bundled nlp.exe is arm64 (Apple Silicon) only, so the
-# .dylib is built for arm64 as well. Intel Macs are not supported.
+# How it fits into the runtime (engine v3.1.45+, which switched the macOS
+# load path from .so to .dylib in NLP-ENGINE-517):
+#   - `nlp -COMPILE` emits the analyzer C++ trees under
+#     <analyzer-dir>/run/ and <analyzer-dir>/kb/ (or just kb/ for
+#     -COMPILEKB when --kb-only).
+#   - This script wraps those trees with an auto-generated StdAfx.h and
+#     builds them into a single SHARED library via cmake.
+#   - The resulting library exports both `run_analyzer(Parse*)` and
+#     `kb_setup(void*)` — engine codegen emits both.
+#   - The library is staged into <analyzer-dir>/bin/ under every name
+#     the engine's load_compiled() (lite/nlp.cpp:1242) and consh's KB
+#     loader (cs/libconsh/cg.cpp:168) look for on macOS.
+#
+# Architecture note: the bundled nlp.exe is arm64 (Apple Silicon) only,
+# so the .dylib is built for arm64 as well. Intel Macs are not
+# supported via this script (use the cloud-compile path for x86_64).
+#
+# Linker handling mirrors what nlp-compile-service's emit-cmake.sh does
+# for the cloud build path, adapted for ld64:
+#   - -DLINUX: the engine's public headers gate Windows-only constructs
+#     on `#ifndef LINUX`; macOS uses the LINUX branch (then the engine
+#     itself distinguishes APPLE inside that branch — see
+#     NLP-ENGINE-517).
+#   - PREFIX "": cmake's default `lib` prefix on SHARED targets is
+#     suppressed so the output filename is <name>.dylib, matching what
+#     the engine and extension look for on disk.
+#   - -Wl,-force_load,<archive> per ICU archive: virtual-class typeinfo
+#     (e.g. icu::ByteSink) must always be linked into the .dylib even
+#     if no analyzer code references it directly. Apple's ld doesn't
+#     accept --whole-archive; -force_load is the per-archive equivalent.
+#   - ld64 re-scans static archives by default for cross-archive
+#     symbols (libconsh's CG::addWord referenced from liblite, etc.),
+#     so no --start-group wrapper is needed here.
 
 set -euo pipefail
 
+KB_ONLY=false
+while [ "${1:-}" = "--kb-only" ]; do
+  KB_ONLY=true
+  shift
+done
+
 if [ "$#" -lt 2 ]; then
-  echo "Usage: $0 <analyzer-dir> <input-file>" >&2
+  echo "Usage: $0 [--kb-only] <analyzer-dir> <input-file>" >&2
   exit 64
 fi
 
@@ -48,9 +83,6 @@ fi
 if [ ! -d "$COMPILE_LIBS/include" ] || [ ! -d "$COMPILE_LIBS/lib" ]; then
   echo "ERROR: compile libraries not found at $COMPILE_LIBS" >&2
   echo "Expected: compile-libs/{include,lib}" >&2
-  echo "(The workflow .github/workflows/nlp-engine-build.yml drops these in" >&2
-  echo " place. Trigger it once upstream attaches nlpengine-compile-libs-macos.zip" >&2
-  echo " to the release.)" >&2
   exit 1
 fi
 if [ ! -f "$INPUT_FILE" ]; then
@@ -60,8 +92,18 @@ fi
 
 export DYLD_LIBRARY_PATH="$REPO_ROOT:${DYLD_LIBRARY_PATH:-}"
 
-echo "==> [1/3] nlp.exe -COMPILE  (emits Cc_code.cpp + Sym*/Con*/Ptr*/St*.cpp under $ANALYZER_DIR/kb)"
-"$NLP_EXE" -COMPILE -ANA "$ANALYZER_DIR" -WORK "$REPO_ROOT" "$INPUT_FILE"
+if [ "$KB_ONLY" = "true" ]; then
+  COMPILE_FLAG="-COMPILEKB"
+  TARGET_NAME="nlp_kb"
+  SRC_GLOB="kb"
+else
+  COMPILE_FLAG="-COMPILE"
+  TARGET_NAME="nlp_analyzer"
+  SRC_GLOB="run|kb"
+fi
+
+echo "==> [1/3] nlp.exe $COMPILE_FLAG  (emits .cpp trees under $ANALYZER_DIR/{$SRC_GLOB}/)"
+"$NLP_EXE" "$COMPILE_FLAG" -ANA "$ANALYZER_DIR" -WORK "$REPO_ROOT" "$INPUT_FILE"
 
 BUILD_ROOT="$ANALYZER_DIR/.nlp-compile"
 SRC_DIR="$BUILD_ROOT/src"
@@ -69,88 +111,109 @@ BUILD_DIR="$BUILD_ROOT/build"
 rm -rf "$BUILD_ROOT"
 mkdir -p "$SRC_DIR"
 
-# Generated engine sources include "StdAfx.h" by convention.
+# Engine-generated .cpp files begin with `#include "StdAfx.h"`; cmake
+# also force-includes this file. Same stub the cloud writes.
 cat > "$SRC_DIR/StdAfx.h" <<'EOF'
 #pragma once
 #include "my_tchar.h"
 EOF
 
-# Sole exported symbol: kb_setup. The engine resolves it via dlsym after
-# dlopening bin/kb.dylib and calls it with the CG (concept graph) instance.
-cat > "$SRC_DIR/kb_setup.cpp" <<'EOF'
-#include "Cc_code.h"
+# Engine static libs. ld64 re-scans automatically, so order isn't
+# sensitive. ICU is handled via per-archive -force_load below.
+ENGINE_LIB_NAMES="prim kbm consh words lite"
 
-extern "C" __attribute__((visibility("default")))
-bool kb_setup(void *cg) {
-    return cc_ini(cg);
-}
-EOF
+if [ "$KB_ONLY" = "true" ]; then
+  GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/kb/*.cpp\")"
+else
+  GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/run/*.cpp\" \"$ANALYZER_DIR/kb/*.cpp\")"
+fi
 
 echo "==> [2/3] Generate CMakeLists.txt"
 cat > "$SRC_DIR/CMakeLists.txt" <<EOF
 cmake_minimum_required(VERSION 3.16)
-project(nlp_kb_library LANGUAGES CXX)
+project(${TARGET_NAME}_library LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_OSX_ARCHITECTURES arm64)
 
-# Hide every symbol by default; kb_setup is opted back in explicitly via
-# __attribute__((visibility("default"))) in kb_setup.cpp.
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+# Engine public headers gate Windows-only constructs on #ifndef LINUX.
+# On macOS the LINUX branch is the right one; engine-internal code then
+# distinguishes Apple via __APPLE__ (NLP-ENGINE-517).
+add_compile_definitions(LINUX)
 
-# Drop the artifact at <analyzer-dir>/bin/kb.dylib (engine's hardcoded path).
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "$ANALYZER_DIR/bin")
 
-file(GLOB GENERATED_CPP "$ANALYZER_DIR/kb/*.cpp")
+$GLOB_LINES
 if(NOT GENERATED_CPP)
-  message(FATAL_ERROR "No generated .cpp files found under $ANALYZER_DIR/kb/ — did -COMPILE succeed?")
+  message(FATAL_ERROR "No generated .cpp files found — did $COMPILE_FLAG succeed?")
 endif()
 
-add_library(nlp_kb SHARED \${GENERATED_CPP} "$SRC_DIR/kb_setup.cpp")
+add_library($TARGET_NAME SHARED \${GENERATED_CPP})
 
-# Force the on-disk filename to "kb.dylib" (no "lib" prefix) so dlopen finds
-# it at the engine's hardcoded path.
-set_target_properties(nlp_kb PROPERTIES
-  OUTPUT_NAME "kb"
+# Suppress cmake's default 'lib' prefix on SHARED targets so the output
+# filename matches what the engine's load_compiled() looks for.
+set_target_properties($TARGET_NAME PROPERTIES
+  OUTPUT_NAME "$TARGET_NAME"
   PREFIX ""
 )
 
-target_include_directories(nlp_kb PRIVATE
+target_include_directories($TARGET_NAME PRIVATE
   "$SRC_DIR"
   "$ANALYZER_DIR"
+  "$ANALYZER_DIR/run"
   "$ANALYZER_DIR/kb"
   "$COMPILE_LIBS/include/Api"
   "$COMPILE_LIBS/include/cs"
 )
 
-target_compile_options(nlp_kb PRIVATE -include StdAfx.h)
-target_link_directories(nlp_kb PRIVATE "$COMPILE_LIBS/lib")
+target_compile_options($TARGET_NAME PRIVATE -include StdAfx.h)
+target_link_directories($TARGET_NAME PRIVATE "$COMPILE_LIBS/lib")
 
-# Engine static libs (link order matters: prim is base; others depend on it).
-# ICU link order is also significant: i18n -> uc -> data.
-target_link_libraries(nlp_kb PRIVATE
-  prim kbm consh words lite
-  icui18n icuuc icudata
+# Engine static libs. ld64 re-scans archives so order isn't sensitive.
+target_link_libraries($TARGET_NAME PRIVATE
+  $ENGINE_LIB_NAMES
 )
 
-find_library(DL_LIBRARY dl)
-if(DL_LIBRARY)
-  target_link_libraries(nlp_kb PRIVATE \${DL_LIBRARY})
-endif()
+# ICU static libs force-loaded so virtual-class typeinfo
+# (icu::ByteSink etc.) is always emitted into the .dylib. Without this,
+# dlopen fails at runtime with undefined-symbol errors. macOS ld uses
+# per-archive -force_load (no group wrapper like GNU ld's
+# --whole-archive).
+target_link_libraries($TARGET_NAME PRIVATE
+  "-Wl,-force_load,$COMPILE_LIBS/lib/libicui18n.a"
+  "-Wl,-force_load,$COMPILE_LIBS/lib/libicuuc.a"
+  "-Wl,-force_load,$COMPILE_LIBS/lib/libicudata.a"
+)
 EOF
 
 echo "==> [3/3] cmake configure + build (Release)"
 cmake -S "$SRC_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release
 cmake --build "$BUILD_DIR" --config Release
 
-OUT="$ANALYZER_DIR/bin/kb.dylib"
-if [ -f "$OUT" ]; then
-  echo
-  echo "Built: $OUT"
-  echo "Run:   $NLP_EXE -COMPILED -ANA $ANALYZER_DIR -WORK $REPO_ROOT $INPUT_FILE"
-else
+OUT="$ANALYZER_DIR/bin/${TARGET_NAME}.dylib"
+if [ ! -f "$OUT" ]; then
   echo "ERROR: expected output $OUT was not produced" >&2
   exit 1
 fi
+
+# Stage the built library under every name the engine's load paths look
+# for. The "u" variants are the UNICODE build flavour; copying them
+# keeps both engine flavours happy without a rebuild.
+echo "==> Staging $(basename "$OUT") into $ANALYZER_DIR/bin/"
+if [ "$KB_ONLY" = "true" ]; then
+  cp -f "$OUT" "$ANALYZER_DIR/bin/kb.dylib"
+  cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.dylib"
+  STAGED="bin/kb.dylib bin/kbu.dylib"
+else
+  cp -f "$OUT" "$ANALYZER_DIR/bin/run.dylib"
+  cp -f "$OUT" "$ANALYZER_DIR/bin/runu.dylib"
+  cp -f "$OUT" "$ANALYZER_DIR/bin/kb.dylib"
+  cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.dylib"
+  STAGED="bin/run.dylib bin/runu.dylib bin/kb.dylib bin/kbu.dylib"
+fi
+
+echo
+echo "Built: $OUT"
+echo "Staged: $STAGED"
+echo "Run:    $NLP_EXE -COMPILED -ANA $ANALYZER_DIR -WORK $REPO_ROOT $INPUT_FILE"


### PR DESCRIPTION
## Summary
- `scripts/compile-analyzer.sh` now builds the **full analyzer** (run/+kb/) by default. `--kb-only` preserves legacy KB-only behaviour.
- `python` submodule bumped to [PYTHON-011](https://github.com/VisualText/python/pull/3), which adds `compileAnalyzer` / `compileLocal` methods + a `compiled=True` kwarg on `analyzeInput`.

## What changed in compile-analyzer.sh
Cmake template adapts what `nlp-compile-service`'s `emit-cmake.sh` does for the cloud build, with macOS `ld64` specifics:

| Setting | Why |
|---|---|
| `-DLINUX` | Engine public headers gate Windows-only constructs on `#ifndef LINUX`; macOS takes the LINUX branch and NLP-ENGINE-517 then distinguishes Apple via `__APPLE__` inside that branch (selects `.dylib` over `.so`). |
| `PREFIX ""` | Suppress cmake's default `lib` prefix so output is `<name>.dylib`, matching the engine's load path. |
| `-Wl,-force_load,<archive>` per ICU lib | Virtual-class typeinfo (`icu::ByteSink` etc.) always linked in. macOS ld doesn't accept GNU `--whole-archive`; `-force_load` is the per-archive equivalent. |
| (no `--start-group` wrapper) | ld64 re-scans static archives natively for cross-archive references (`CG::addWord` in `libconsh.a` referenced from `liblite.a`). |

`CMAKE_OSX_ARCHITECTURES arm64` preserved — bundled `nlp.exe` is Apple Silicon only.

Successful build is staged into `<analyzer-dir>/bin/` under every name the engine's load paths look for: `run.dylib` / `runu.dylib` / `kb.dylib` / `kbu.dylib` (or just `kb` / `kbu` for `--kb-only`).

The manual `kb_setup.cpp` shim is dropped — engine v3.1.45+ emits the wrapper automatically (NLP-ENGINE-495).

## Test plan
- [ ] `scripts/compile-analyzer.sh data/rfb data/rfb/input/text.txt` produces `bin/run.dylib` + `bin/kb.dylib` + `.u` variants.
- [ ] `./nlp.exe -COMPILED -ANA data/rfb -WORK . data/rfb/input/text.txt` runs without falling back to interpreted.
- [ ] Legacy: `scripts/compile-analyzer.sh --kb-only data/rfb data/rfb/input/text.txt` still produces `bin/kb.dylib`.
