### PR TITLE
feat: add analyzer-only compile mode (-COMPILEANA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,13 @@ shared libraries that the engine `dlopen`s at runtime — the analyzer
 runs entirely from compiled code, so source edits to `.nlp` files
 between runs don't affect the output until you recompile.
 
-| Script | What it does | Output |
-|--------|--------------|--------|
-| [scripts/compile-analyzer.sh](scripts/compile-analyzer.sh) | Runs `nlp.exe -COMPILE` (emits the analyzer C++ trees under `<analyzer>/run/` and `<analyzer>/kb/`), then links everything into a single SHARED library against `compile-libs/`. The library exports both `run_analyzer(Parse*)` and `kb_setup(void*)` (engine codegen emits both). | `<analyzer>/bin/run.dylib`<br>`<analyzer>/bin/runu.dylib`<br>`<analyzer>/bin/kb.dylib`<br>`<analyzer>/bin/kbu.dylib` |
+| Mode | Flag | What it does | Output |
+|------|------|--------------|--------|
+| Full (default) | `-COMPILE` | Runs `nlp.exe -COMPILE` (emits the analyzer C++ trees under `<analyzer>/run/` and `<analyzer>/kb/`), then links everything into a single SHARED library against `compile-libs/`. The library exports both `run_analyzer(Parse*)` and `kb_setup(void*)` (engine codegen emits both). | `<analyzer>/bin/run.dylib`<br>`<analyzer>/bin/runu.dylib`<br>`<analyzer>/bin/kb.dylib`<br>`<analyzer>/bin/kbu.dylib` |
+| KB only | `--kb-only` (`-COMPILEKB`) | Compiles only the knowledge base. Use when only the KB changed. | `<analyzer>/bin/kb.dylib`<br>`<analyzer>/bin/kbu.dylib` |
+| Analyzer only | `--analyzer-only` (`-COMPILEANA`) | Compiles only the analyzer rules, leaving any existing `kb.dylib` in place. Use when only the rules changed and the KB is already compiled. | `<analyzer>/bin/run.dylib`<br>`<analyzer>/bin/runu.dylib` |
+
+[scripts/compile-analyzer.sh](scripts/compile-analyzer.sh) drives all three modes.
 
 The same library is staged under all four filenames so the engine's
 load paths find it whether it's looking for the ANSI or UNICODE
@@ -111,8 +115,12 @@ Usage:
 # Default: full-analyzer compile (run + kb):
 ./scripts/compile-analyzer.sh data/rfb data/rfb/input/text.txt
 
-# Legacy: KB-only compile (matches the pre-NLP-ENGINE-MAC-008 behaviour):
+# KB-only compile (-COMPILEKB): rebuild just kb.dylib / kbu.dylib:
 ./scripts/compile-analyzer.sh --kb-only data/rfb data/rfb/input/text.txt
+
+# Analyzer-only compile (-COMPILEANA): rebuild just run.dylib / runu.dylib,
+# leaving the existing kb.dylib in place. Use when only the rules changed:
+./scripts/compile-analyzer.sh --analyzer-only data/rfb data/rfb/input/text.txt
 
 # Run with the compiled artifacts:
 ./nlp.exe -COMPILED -ANA data/rfb -WORK . data/rfb/input/text.txt

--- a/scripts/compile-analyzer.sh
+++ b/scripts/compile-analyzer.sh
@@ -56,14 +56,17 @@
 
 set -euo pipefail
 
-KB_ONLY=false
-while [ "${1:-}" = "--kb-only" ]; do
-  KB_ONLY=true
+MODE="full"
+while [ "${1:-}" = "--kb-only" ] || [ "${1:-}" = "--analyzer-only" ]; do
+  case "$1" in
+    --kb-only)       MODE="kb" ;;
+    --analyzer-only) MODE="ana" ;;
+  esac
   shift
 done
 
 if [ "$#" -lt 2 ]; then
-  echo "Usage: $0 [--kb-only] <analyzer-dir> <input-file>" >&2
+  echo "Usage: $0 [--kb-only|--analyzer-only] <analyzer-dir> <input-file>" >&2
   exit 64
 fi
 
@@ -92,15 +95,23 @@ fi
 
 export DYLD_LIBRARY_PATH="$REPO_ROOT:${DYLD_LIBRARY_PATH:-}"
 
-if [ "$KB_ONLY" = "true" ]; then
-  COMPILE_FLAG="-COMPILEKB"
-  TARGET_NAME="nlp_kb"
-  SRC_GLOB="kb"
-else
-  COMPILE_FLAG="-COMPILE"
-  TARGET_NAME="nlp_analyzer"
-  SRC_GLOB="run|kb"
-fi
+case "$MODE" in
+  kb)
+    COMPILE_FLAG="-COMPILEKB"
+    TARGET_NAME="nlp_kb"
+    SRC_GLOB="kb"
+    ;;
+  ana)
+    COMPILE_FLAG="-COMPILEANA"
+    TARGET_NAME="nlp_run"
+    SRC_GLOB="run"
+    ;;
+  *)
+    COMPILE_FLAG="-COMPILE"
+    TARGET_NAME="nlp_analyzer"
+    SRC_GLOB="run|kb"
+    ;;
+esac
 
 echo "==> [1/3] nlp.exe $COMPILE_FLAG  (emits .cpp trees under $ANALYZER_DIR/{$SRC_GLOB}/)"
 "$NLP_EXE" "$COMPILE_FLAG" -ANA "$ANALYZER_DIR" -WORK "$REPO_ROOT" "$INPUT_FILE"
@@ -122,11 +133,11 @@ EOF
 # sensitive. ICU is handled via per-archive -force_load below.
 ENGINE_LIB_NAMES="prim kbm consh words lite"
 
-if [ "$KB_ONLY" = "true" ]; then
-  GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/kb/*.cpp\")"
-else
-  GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/run/*.cpp\" \"$ANALYZER_DIR/kb/*.cpp\")"
-fi
+case "$MODE" in
+  kb)  GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/kb/*.cpp\")" ;;
+  ana) GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/run/*.cpp\")" ;;
+  *)   GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/run/*.cpp\" \"$ANALYZER_DIR/kb/*.cpp\")" ;;
+esac
 
 echo "==> [2/3] Generate CMakeLists.txt"
 cat > "$SRC_DIR/CMakeLists.txt" <<EOF
@@ -201,17 +212,25 @@ fi
 # for. The "u" variants are the UNICODE build flavour; copying them
 # keeps both engine flavours happy without a rebuild.
 echo "==> Staging $(basename "$OUT") into $ANALYZER_DIR/bin/"
-if [ "$KB_ONLY" = "true" ]; then
-  cp -f "$OUT" "$ANALYZER_DIR/bin/kb.dylib"
-  cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.dylib"
-  STAGED="bin/kb.dylib bin/kbu.dylib"
-else
-  cp -f "$OUT" "$ANALYZER_DIR/bin/run.dylib"
-  cp -f "$OUT" "$ANALYZER_DIR/bin/runu.dylib"
-  cp -f "$OUT" "$ANALYZER_DIR/bin/kb.dylib"
-  cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.dylib"
-  STAGED="bin/run.dylib bin/runu.dylib bin/kb.dylib bin/kbu.dylib"
-fi
+case "$MODE" in
+  kb)
+    cp -f "$OUT" "$ANALYZER_DIR/bin/kb.dylib"
+    cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.dylib"
+    STAGED="bin/kb.dylib bin/kbu.dylib"
+    ;;
+  ana)
+    cp -f "$OUT" "$ANALYZER_DIR/bin/run.dylib"
+    cp -f "$OUT" "$ANALYZER_DIR/bin/runu.dylib"
+    STAGED="bin/run.dylib bin/runu.dylib"
+    ;;
+  *)
+    cp -f "$OUT" "$ANALYZER_DIR/bin/run.dylib"
+    cp -f "$OUT" "$ANALYZER_DIR/bin/runu.dylib"
+    cp -f "$OUT" "$ANALYZER_DIR/bin/kb.dylib"
+    cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.dylib"
+    STAGED="bin/run.dylib bin/runu.dylib bin/kb.dylib bin/kbu.dylib"
+    ;;
+esac
 
 echo
 echo "Built: $OUT"


### PR DESCRIPTION
Adds a third compile mode (`--analyzer-only` → `-COMPILEANA`) to `scripts/compile-analyzer` matching nlp-engine 3.6.0, alongside the default full build and KB-only. Builds and stages only `run.dylib` / `runu.dylib`, leaving any existing `kb.dylib` in place — for when only the rules changed and the KB is already compiled. README updated.

Follow-up: bump the `python` submodule once VisualText/python#4 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)